### PR TITLE
fix documentation HorseStore.huff

### DIFF
--- a/src/HorseStore.huff
+++ b/src/HorseStore.huff
@@ -63,8 +63,8 @@
 
 #define macro GET_HORSE_FED_TIMESTAMP() = takes (0) returns (0) {
     0x04 calldataload       // [horseId]
-    GET_SLOT_FROM_KEY(0x00) // [horseFedTimestamp]
-    sload                   // []
+    GET_SLOT_FROM_KEY(0x00) // [SlotForHorseFedTimestamp]
+    sload                   // [horseFedTimestamp]
 
     0x00 mstore             // [] Store value in memory.
     0x20 0x00 return        // Returns what' sin memory


### PR DESCRIPTION
## Wrong documentation in `HorseStore.huff::GET_HORSE_FED_TIMESTAMP`            

### Relevant GitHub Links
	
https://github.com/Cyfrin/2024-01-horse-store/blob/main/src/HorseStore.huff#L64C1-L71C2

## Description

The documentation in `GET_HORSE_FED_TIMESTAMP` incorrectly indicates that `GET_SLOT_FROM_KEY` returns the timestamp when the horse is fed. In reality, it returns the slot where this information is stored. Sload reads from the slot and places the timestamp information on the stack. The documentation suggests that the stack is empty at this point, which is not true. In addition, using `mstore` requires two elements on the stack to work.

```javascript
#define macro GET_HORSE_FED_TIMESTAMP() = takes (0) returns (0) {
    0x04 calldataload       // [horseId]
@>    GET_SLOT_FROM_KEY(0x00) // [horseFedTimestamp]
@>    sload                   // []

    0x00 mstore             // [] Store value in memory.
    0x20 0x00 return        // Returns what's in memory
}
```

## Impact

Huff is already a low-level language with inherent complexity. Incorrect documentation will confuse a developer or an auditor.

## Recommended Mitigation

Here is a more relevant documentation:

```diff
#define macro GET_HORSE_FED_TIMESTAMP() = takes (0) returns (0) {
    0x04 calldataload       // [horseId]
-    GET_SLOT_FROM_KEY(0x00) // [horseFedTimestamp]
-    sload                   // []
+    GET_SLOT_FROM_KEY(0x00) // [SlotForHorseFedTimestamp]
+    sload                   // [horseFedTimestamp]

    0x00 mstore             // [] Store value in memory.
    0x20 0x00 return        // Returns what's in memory
}
```

[This is submission #73 of HorseStore contest.](https://www.codehawks.com/submissions/clr6s75ut00013qg9z8bpkalo/73)